### PR TITLE
Fixing wc annoying padding

### DIFF
--- a/minimal.zsh
+++ b/minimal.zsh
@@ -109,10 +109,10 @@ function minimal_infoline {
         local user_host_pwd="$_grey%n$w@$_grey%m$w:$_grey%~$w"
         user_host_pwd="${${(%)user_host_pwd}//\//$w/$_grey}"
 
-        local v_files="$(ls -1 | wc -l)"
-        local h_files="$(ls -1A | wc -l)"
+        local v_files="$(ls -1 | sed -n '$=')"
+        local h_files="$(ls -1A | sed -n '$=')"
 
-        local job_n="$(jobs | wc -l)"
+        local job_n="$(jobs | sed -n '$=')"
 
         local iline="[$user_host_pwd] [$_grey$v_files$w ($_grey$h_files$w)]"
         [ "$job_n" -gt 0 ] && iline="$iline [$_grey$job_n$w&]"
@@ -126,7 +126,7 @@ function minimal_infoline {
 
 function minimal_wrap_output {
     local output="$1"
-    local output_len="$(echo "$output" | wc -l)"
+    local output_len="$(echo "$output" | sed -n '$=')"
     if [ -n "$output" ]; then
         if [ "$output_len" -gt "$((LINES - 2))" -a -n "$PAGER" ]; then
             printf "$output\n" | "$PAGER" -R


### PR DESCRIPTION
Fixing annoying padding wc can produce:
```
λ › [godm@umbrella:~] [      19 (     106)]
```
now it's:
```
λ › [godm@umbrella:~] [20 (107)]
```

There're couple of ways how to count line numbers:
- cat big.txt | wc -l
- cat big.txt| awk 'END{print NR}'
- cat big.txt| grep -c ".*"
- cat big.txt| sed -n '$='

and time running for each of commands:
```
λ › time cat big.txt| awk 'END{print NR}'                                                                                                                            ~
128457
cat big.txt  0.00s user 0.00s system 1% cpu 0.293 total
awk 'END{print NR}'  0.29s user 0.00s system 99% cpu 0.295 total
λ › time cat big.txt| grep -c ".*"                                                                                                                                   ~
128457
cat big.txt  0.00s user 0.00s system 2% cpu 0.250 total
grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn} -c ".*"  0.25s user 0.00s system 99% cpu 0.251 total
λ › time cat big.txt| sed -n '$='                                                                                                                                    ~
128457
cat big.txt  0.00s user 0.00s system 11% cpu 0.043 total
sed -n '$='  0.04s user 0.00s system 95% cpu 0.042 total
λ › time cat big.txt| wc -l                                                                                                                                          ~
  128457
cat big.txt  0.00s user 0.00s system 54% cpu 0.011 total
wc -l  0.01s user 0.00s system 86% cpu 0.010 total
```