### PR TITLE
Prettify the Magic Enter output for OS X.

### DIFF
--- a/minimal.zsh
+++ b/minimal.zsh
@@ -21,9 +21,10 @@ function _isfn {
 if ! _isfn minimal_magic_output; then
     function minimal_magic_output {
         if [ "$(uname)" = "Darwin" ] && ! ls --version &> /dev/null; then
-            ls -C -G
+            # reserve 4 chars for the "  | "
+            COLUMNS=$((COLUMNS - 4)) CLICOLOR_FORCE=1 ls -C -G
         else
-            ls -C --color="always" -w $COLUMNS
+            ls -C --color="always" -w $((COLUMNS - 4))
         fi
 
         git -c color.status=always status -sb 2> /dev/null


### PR DESCRIPTION
* Force colorize it.
* Format it to the width of the terminal.

Before:
<img width="1280" alt="screen shot 2017-09-08 at 12 04 24 am" src="https://user-images.githubusercontent.com/5601392/30200385-7e14b514-942b-11e7-82d8-efe029b9321b.png">
After:
<img width="1280" alt="screen shot 2017-09-08 at 12 07 20 am" src="https://user-images.githubusercontent.com/5601392/30200391-84abd5ec-942b-11e7-9b0e-7019fdd96e8e.png">
