### PR TITLE
Fix unknown file attribute error

### DIFF
--- a/minimal.zsh
+++ b/minimal.zsh
@@ -163,7 +163,8 @@ function mnml_me_git {
 # Wrappers & utils
 # join outpus of components
 function _mnml_wrap {
-    local arr=()
+    local -a arr
+    arr=()
     local cmd_out=""
     local cmd
     for cmd in ${(P)1}; do
@@ -183,7 +184,8 @@ function _mnml_iline {
 
 # display magic enter
 function _mnml_me {
-    local output=()
+    local -a output
+    output=()
     local cmd_out=""
     local cmd
     for cmd in $MNML_MAGICENTER; do
@@ -222,7 +224,8 @@ function _mnml_buffer-empty {
 function _mnml_bind_widgets() {
     zmodload zsh/zleparameter
 
-    local to_bind=(zle-line-init zle-keymap-select buffer-empty)
+    local -a to_bind
+    to_bind=(zle-line-init zle-keymap-select buffer-empty)
 
     typeset -F SECONDS
     local zle_wprefix=s$SECONDS-r$RANDOM


### PR DESCRIPTION
Older versions of ZSH (pre 5.1) are unable to define local arrays in single lines.

Reproducing the issue locally:
```
$ zsh --version
zsh 5.0.7 (x86_64-unknown-linux-gnu)
$ source ~/.zshrc
_mnml_bind_widgets:3: unknown file attribute: z
```

In order to fix this I just modified all local arrays to be initialized on a previous line. This also seems forwards compatible and works for my other host which is running `zsh 5.2 (x86_64-apple-darwin16.0)`
```
# before
local to_bind=(zle-line-init zle-keymap-select buffer-empty)
# after
local -a to_bind
to_bind=(zle-line-init zle-keymap-select buffer-empty)
```

Sources:
* http://www.zsh.org/mla/users/1999/msg00011.html
* https://github.com/hlissner/zsh-autopair/issues/5