### PR TITLE
Add .zsh-theme file for compatibility with oh-my-zsh

### DIFF
--- a/minimal.zsh-theme
+++ b/minimal.zsh-theme
@@ -1,0 +1,1 @@
+minimal.zsh


### PR DESCRIPTION
Hi,

[oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) requires theme files to have `zsh-theme` extension. This PR adds `minimal.zsh-theme` file which sources main file to make `minimal` comptatible with `oh-my-zsh`.

In order to use `minimal` with `oh-my-zsh` users can now clone it to `~/.oh-my-zsh/custom/themes` and [specify it as any other theme](https://github.com/robbyrussell/oh-my-zsh#selecting-a-theme).

p.s. Thank you for sharing your theme, it is awesome!