### PR TITLE
Introduce a setting to define the ellipsis character

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Different components can use these (global) settings:
 - `MNML_USER_CHAR`: Character used for unprivileged users (default: `λ`)
 - `MNML_INSERT_CHAR`: Character used for vi insert mode (default: `›`)
 - `MNML_NORMAL_CHAR`: Character used for vi normal mode (default: `·`)
+- `MNML_ELLIPSIS_CHAR`: Character used when truncating long words (default: `..`)
 
 Three global arrays handle the definition and rendering position of the components:
 
@@ -94,7 +95,7 @@ If `N` is not specified, it will take a default value of `2`. If is specified bu
 
 If `LEN` is not specified or `LEN <= 0` no truncation will be performed on the segments. If `0 < LEN < 4` it will be set to `4`.
 
-When a segment length is greater than `LEN`'s value, the first `LEN / 2 - 1` characters are printed, followed by `..`, followed by the last `LEN / 2 - 1` characters.  
+When a segment length is greater than `LEN`'s value, the first `LEN / 2 - 1` characters are printed, followed by `$MNML_ELLIPSIS_CHAR`, followed by the last `LEN / 2 - 1` characters.
 For example, with `LEN = 8` and `0123456789` as segment, `012..789` is displayed.
 
 ### Git branch status

--- a/minimal.zsh
+++ b/minimal.zsh
@@ -5,6 +5,7 @@ MNML_ERR_COLOR="${MNML_ERR_COLOR:-1}"
 MNML_USER_CHAR="${MNML_USER_CHAR:-λ}"
 MNML_INSERT_CHAR="${MNML_INSERT_CHAR:-›}"
 MNML_NORMAL_CHAR="${MNML_NORMAL_CHAR:-·}"
+MNML_ELLIPSIS_CHAR="${MNML_ELLIPSIS_CHAR:-..}"
 
 [ "${+MNML_PROMPT}" -eq 0 ] && MNML_PROMPT=(mnml_ssh mnml_pyenv mnml_status mnml_keymap)
 [ "${+MNML_RPROMPT}" -eq 0 ] && MNML_RPROMPT=('mnml_cwd 2 0' mnml_git)
@@ -38,6 +39,7 @@ function mnml_keymap {
 }
 
 function mnml_cwd {
+    local echar="$MNML_ELLIPSIS_CHAR"
     local segments="${1:-2}"
     local seg_len="${2:-0}"
 
@@ -60,7 +62,7 @@ function mnml_cwd {
     for i in {1..${#cwd}}; do
         pi="$cwd[$i]"
         if [ "$seg_len" -gt 0 ] && [ "${#pi}" -gt "$seg_len" ]; then
-            cwd[$i]="${pi:0:$seg_hlen}$_w..$_g${pi: -$seg_hlen}"
+            cwd[$i]="${pi:0:$seg_hlen}$_w$echar$_g${pi: -$seg_hlen}"
         fi
     done
 


### PR DESCRIPTION
The ellipsis character (actually two characters by default) is
used when long names have to be truncated (e.g. in `mnml_cwd`).
Allow the user to change that setting as they see fit.

The Unicode ellipsis character (`…`) is a good candidate in my opinion.