### PR TITLE
Introduce a setting to define the background job mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Different components can use these (global) settings:
 
 - `MNML_OK_COLOR`: Color for successful things (default: `2`)
 - `MNML_ERR_COLOR`: Color for failures (default: `1`)
+- `MNML_BACKGROUND_JOB_MODE`: Mode applied when there are background jobs (default: `4`)
 - `MNML_USER_CHAR`: Character used for unprivileged users (default: `λ`)
 - `MNML_INSERT_CHAR`: Character used for vi insert mode (default: `›`)
 - `MNML_NORMAL_CHAR`: Character used for vi normal mode (default: `·`)
@@ -70,7 +71,7 @@ These values can be changed interactively or in any of the init files.
 An indicator displaying the following information:
 - user privilege: `#` is printed when root, `$MNML_USER_CHAR` otherwise.
 - last command success: indicator's color is set to `$MNML_OK_COLOR` when the last command was successful, `$MNML_ERR_COLOR` otherwise.
-- background jobs: indicator is underlined if at least one job is in background.
+- background jobs: `$MNML_BACKGROUND_JOB_MODE` is applied to the indicator if at least one job is in background.
 
 ### Keymap
 

--- a/minimal.zsh
+++ b/minimal.zsh
@@ -2,6 +2,8 @@
 MNML_OK_COLOR="${MNML_OK_COLOR:-2}"
 MNML_ERR_COLOR="${MNML_ERR_COLOR:-1}"
 
+MNML_BACKGROUND_JOB_MODE=${MNML_BACKGROUND_JOB_MODE:-4}
+
 MNML_USER_CHAR="${MNML_USER_CHAR:-λ}"
 MNML_INSERT_CHAR="${MNML_INSERT_CHAR:-›}"
 MNML_NORMAL_CHAR="${MNML_NORMAL_CHAR:-·}"
@@ -20,7 +22,7 @@ function mnml_status {
 
     local job_ansi="0"
     if [ -n "$(jobs | sed -n '$=')" ]; then
-        job_ansi="4"
+        job_ansi="$MNML_BACKGROUND_JOB_MODE"
     fi
 
     local err_ansi="$MNML_OK_COLOR"


### PR DESCRIPTION
The background job mode is applied to the status indicator
if there is at least one job running in the background.
Allow the user to change that setting as they see fit.