### PR TITLE
Circumvent aliases for ls

### DIFF
--- a/minimal.zsh
+++ b/minimal.zsh
@@ -14,6 +14,7 @@ MNML_BGJOB_MODE=${MNML_BGJOB_MODE:-4}
 
 [ "${+MNML_MAGICENTER}" -eq 0 ] && MNML_MAGICENTER=(mnml_me_dirs mnml_me_ls mnml_me_git)
 
+
 # Components
 function mnml_status {
     local okc="$MNML_OK_COLOR"
@@ -160,11 +161,12 @@ function mnml_jobs {
 }
 
 function mnml_files {
+    local _ls="$(env which ls)"
     local _w="%{\e[0m%}"
     local _g="%{\e[38;5;244m%}"
 
-    local a_files="$(ls -1A | sed -n '$=')"
-    local v_files="$(ls -1 | sed -n '$=')"
+    local a_files="$($_ls -1A | sed -n '$=')"
+    local v_files="$($_ls -1 | sed -n '$=')"
     local h_files="$((a_files - v_files))"
 
     local output="${_w}[$_g${v_files:-0}"
@@ -191,7 +193,7 @@ function mnml_me_ls {
     if [ "$(uname)" = "Darwin" ] && ! ls --version &> /dev/null; then
         COLUMNS=$COLUMNS CLICOLOR_FORCE=1 ls -C -G -F
     else
-        ls -C -F --color="always" -w $COLUMNS
+        env ls -C -F --color="always" -w $COLUMNS
     fi
 }
 

--- a/minimal.zsh
+++ b/minimal.zsh
@@ -163,8 +163,8 @@ function mnml_files {
     local _w="%{\e[0m%}"
     local _g="%{\e[38;5;244m%}"
 
-    local a_files="$(ls -1A | sed -n '$=')"
-    local v_files="$(ls -1 | sed -n '$=')"
+    local a_files="$("ls" -1A | wc -l)"
+    local v_files="$("ls" -1 | wc -l)"
     local h_files="$((a_files - v_files))"
 
     local output="${_w}[$_g${v_files:-0}"
@@ -191,7 +191,7 @@ function mnml_me_ls {
     if [ "$(uname)" = "Darwin" ] && ! ls --version &> /dev/null; then
         COLUMNS=$COLUMNS CLICOLOR_FORCE=1 ls -C -G -F
     else
-        ls -C -F --color="always" -w $COLUMNS
+        "ls" -C -F --color="always" -w $COLUMNS
     fi
 }
 

--- a/minimal.zsh
+++ b/minimal.zsh
@@ -163,8 +163,8 @@ function mnml_files {
     local _w="%{\e[0m%}"
     local _g="%{\e[38;5;244m%}"
 
-    local a_files="$("ls" -1A | wc -l)"
-    local v_files="$("ls" -1 | wc -l)"
+    local a_files="$(ls -1A | sed -n '$=')"
+    local v_files="$(ls -1 | sed -n '$=')"
     local h_files="$((a_files - v_files))"
 
     local output="${_w}[$_g${v_files:-0}"
@@ -191,7 +191,7 @@ function mnml_me_ls {
     if [ "$(uname)" = "Darwin" ] && ! ls --version &> /dev/null; then
         COLUMNS=$COLUMNS CLICOLOR_FORCE=1 ls -C -G -F
     else
-        "ls" -C -F --color="always" -w $COLUMNS
+        ls -C -F --color="always" -w $COLUMNS
     fi
 }
 


### PR DESCRIPTION
My config uses exa as a replacement for ls and defines aliases.
'exa' is not option-compatible with 'coreutils ls' so the functions break.
The double-quote syntax forces usage of the installed binary of the given name.

No change to behavior in Darwin, as i could not test it.

Also uses 'wc' instead of 'sed', as 'sed' is overkill for this task.
'wc' is also part of 'coreutils', so no additional dependencies.