### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ A minimal and extensible zsh theme.
 zgen load subnixr/minimal
 ```
 
+[Fig](https://fig.io):
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `minimal` in just one click.
+
+<a href="https://fig.io/plugins/other/minimal" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 [Antigen](https://github.com/zsh-users/antigen):
 ```sh
 antigen bundle subnixr/minimal


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Minimal is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!